### PR TITLE
Remove old code from the old debug component

### DIFF
--- a/DebugClassLoader.php
+++ b/DebugClassLoader.php
@@ -399,7 +399,6 @@ class DebugClassLoader
         if (
             'Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerForV7' === $class
             || 'Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerForV6' === $class
-            || 'Test\Symfony\Component\Debug\Tests' === $refl->getNamespaceName()
         ) {
             return [];
         }

--- a/Tests/Exception/FlattenExceptionTest.php
+++ b/Tests/Exception/FlattenExceptionTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\ErrorHandler\Tests\Exception;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Debug\Exception\FatalThrowableError;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;


### PR DESCRIPTION
See some old references from the old debug component.
So may be it's could be great to cleanup this part.

#SymfonyHackday