### PR TITLE
Better fix for xdebug >= 3.0 when trying to produce a trace during FatalError situations

### DIFF
--- a/Error/FatalError.php
+++ b/Error/FatalError.php
@@ -33,7 +33,10 @@ class FatalError extends \Error
                 }
             }
         } elseif (null !== $traceOffset) {
-            if (\function_exists('xdebug_get_function_stack') && $trace = @xdebug_get_function_stack()) {
+            // xdebug >= 3.0 has an ini xdebug.mode (not present in v2) that must be set to 'develop' for xdebug_get_function_stack()
+            if (\function_exists('xdebug_get_function_stack') && in_array(ini_get('xdebug.mode'), ['develop', false], true)) {
+                $trace = xdebug_get_function_stack();
+
                 if (0 < $traceOffset) {
                     array_splice($trace, -$traceOffset);
                 }


### PR DESCRIPTION
EDIT: sorry, moving to symfony/symfony

When the application is already dealing with a FatalError, we should avoid calling xdebug in situations we know will produce another php_error from within xdebug itself.

`xdebug_get_function_stack()` can be called in xdebug < 3.0 (ie: `ini_get('xdebug.mode')` will return `false` since it doesn't not exist

OR

`xdebug_get_function_stack()` can be called in xdebug >= 3.0 when `ini_get('xdebug.mode')` returns `develop`.

@derickr thoughts?