### PR TITLE
Center icons vertically in trace list

### DIFF
--- a/Resources/assets/css/exception.css
+++ b/Resources/assets/css/exception.css
@@ -225,7 +225,7 @@ header .container { display: flex; justify-content: space-between; }
 .trace-line + .trace-line { border-top: var(--border); }
 .trace-line:hover { background: var(--base-1); }
 .trace-line a { color: var(--base-6); }
-.trace-line .icon { opacity: .4; position: absolute; left: 10px; top: 11px; }
+.trace-line .icon { opacity: .4; position: absolute; left: 10px; }
 .trace-line .icon svg { fill: var(--base-5); height: 16px; width: 16px; }
 .trace-line .icon.icon-copy { left: auto; top: auto; padding-left: 5px; display: none }
 .trace-line:hover .icon.icon-copy:not(.hidden) { display: inline-block }


### PR DESCRIPTION
Make icons centered in trace list and not on the bottom trace-line-header div

Before:
![grafik](https://user-images.githubusercontent.com/22859658/157042250-51bb70c3-0350-4d84-8c80-e5ceb2e72e36.png)
After:
![grafik](https://user-images.githubusercontent.com/22859658/157042208-8023d18a-f39b-45b1-a0ba-7f3522d3be0f.png)
